### PR TITLE
fix: patch for v1.8.3 deployment

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,23 @@
+kind: pipeline
+type: docker
+name: controller
+
+features:
+  docker-daemon@v1:
+    enabled: true
+
+trigger:
+  event: [tag]
+
+steps:
+  - name: build controller
+    image: golang:1.22
+    commands:
+      - make controller
+
+  - name: build & push image
+    image: plugins/harbor
+    settings:
+      repo: ${DRONE_REPO}
+      tags:
+        - ${DRONE_TAG}

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,15 +7,16 @@ features:
     enabled: true
 
 trigger:
-  event: [tag]
+  event:
+    - tag
 
 steps:
-  - name: build controller
+  - name: build
     image: golang:1.22
     commands:
       - make controller
-
-  - name: build & push image
+        
+  - name: push
     image: plugins/harbor
     settings:
       repo: ${DRONE_REPO}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+# Fork of Argo Rollouts
+
+This is a fork of Argo Rollouts which we patch with nessecary before they're merged upstream.
+
+## Workflow
+
+The `dh-main` acts as the main branch of our fork. When a new Argo Rollouts is released it should be rebased into
+this branch. 
+
+A release is triggered by creating a new tag from this branch. 
+
+It should follow the convention of: `{argo-version}-dhpatch-{version}`
+
+- `argo-version`: Corresponds to the latest Argo Rollouts version, such as `v1.7.2`
+- `version`: Should be incremented for every "release" or "patch" created for this particular version.
+
+Example: `v1.7.2-dhpatch-1`
 
 # Argo Rollouts - Progressive Delivery for Kubernetes
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fork of Argo Rollouts
 
-This is a fork of Argo Rollouts which we patch with nessecary before they're merged upstream.
+This is a fork of Argo Rollouts which we patch with necessary changes before they're merged upstream.
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ A release is triggered by creating a new tag from this branch.
 
 It should follow the convention of: `{argo-version}-dhpatch-{version}`
 
-- `argo-version`: Corresponds to the latest Argo Rollouts version, such as `v1.7.2`
+- `argo-version`: Corresponds to the latest Argo Rollouts version, such as `v1.8.3`
 - `version`: Should be incremented for every "release" or "patch" created for this particular version.
 
-Example: `v1.7.2-dhpatch-1`
+Example: `v1.8.3-dhpatch-1`
 
 # Argo Rollouts - Progressive Delivery for Kubernetes
 

--- a/rollout/trafficrouting.go
+++ b/rollout/trafficrouting.go
@@ -7,10 +7,9 @@ import (
 	"strings"
 
 	"github.com/argoproj/argo-rollouts/utils/annotations"
+	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting/plugin"
-
-	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/rollout/trafficrouting"
@@ -135,23 +134,6 @@ func (c *Controller) NewTrafficRoutingReconciler(roCtx *rolloutContext) ([]traff
 	return nil, nil
 }
 
-func (c *rolloutContext) checkReplicasAvailable(rs *appsv1.ReplicaSet, desiredWeight int32) bool {
-	if rs == nil {
-		return false
-	}
-	availableReplicas := rs.Status.AvailableReplicas
-	totalReplicas := *c.rollout.Spec.Replicas
-
-	desiredReplicas := (desiredWeight * totalReplicas) / 100
-	if availableReplicas < desiredReplicas {
-		c.log.Infof("ReplicaSet '%s' has %d available replicas, waiting for %d", rs.Name, availableReplicas, desiredReplicas)
-		return false
-	}
-
-	return true
-
-}
-
 // this currently only be used in the canary strategy
 func (c *rolloutContext) reconcileTrafficRouting() error {
 	reconcilers, err := c.newTrafficRoutingReconciler(c)
@@ -263,9 +245,11 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 			}
 		}
 
-		if !c.checkReplicasAvailable(c.stableRS, weightutil.MaxTrafficWeight(c.rollout)-desiredWeight) {
+		// Guardrail, which makes sure that we don't switch traffic before there's enough replicas.
+		if !c.checkReplicasAvailable(c.newRS, desiredWeight) {
 			return nil
 		}
+
 		// We need to check for revision > 1 because when we first install the rollout we run step 0 this prevents that.
 		// There is a bigger fix needed for the reasons on why we run step 0 on rollout install, that needs to be explored.
 		revision, revisionFound := annotations.GetRevisionAnnotation(c.rollout)
@@ -330,6 +314,24 @@ func (c *rolloutContext) reconcileTrafficRouting() error {
 		}
 	}
 	return nil
+}
+
+func (c *rolloutContext) checkReplicasAvailable(rs *appsv1.ReplicaSet, desiredWeight int32) bool {
+	if rs == nil {
+		return false
+	}
+
+	availableReplicas := rs.Status.AvailableReplicas
+	totalReplicas := *c.rollout.Spec.Replicas
+
+	desiredReplicas := (desiredWeight * totalReplicas) / 100
+
+	if availableReplicas < desiredReplicas {
+		c.log.Infof("ReplicaSet '%s' has %d available replicas, waiting for %d", rs.Name, availableReplicas, desiredReplicas)
+		return false
+	}
+
+	return true
 }
 
 // calculateDesiredWeightOnAbortOrStableRollback returns the desired weight to use when we are either


### PR DESCRIPTION
## Summary
This PR adds patches on top of clean Argo Rollouts **v1.8.3** for production deployment.